### PR TITLE
Update WC tested to: 4.9.1

### DIFF
--- a/cryptowoo-monero-addon.php
+++ b/cryptowoo-monero-addon.php
@@ -16,7 +16,7 @@ if ( ! defined( 'ABSPATH' ) ) {
  * License: GPLv2
  * Text Domain: cryptowoo-xmr-addon
  * Domain Path: /lang
- * WC tested up to: 3.2.5
+ * WC tested up to: 4.9.1
  */
 
 require_once( 'includes/monerowp/library.php' );


### PR DESCRIPTION
This plugin has been running perfectly on 4.9.0 and 4.9.1 for some time. Incrementing the value will prevent WC showing a warning when updating WC.